### PR TITLE
Harden devconsole entry points

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -44,11 +44,7 @@
     },
     {
       "matches": [
-        "http://localhost/*",
-        "http://api-dev.padolabs.org:38082/*",
-        "http://api-dev.padolabs.org:38089/*",
-        "https://dev.primuslabs.xyz/*",
-        "http://35.200.124.249/*"
+        "https://dev.primuslabs.xyz/*"
       ],
       "js": ["devconsole.bundle.js"],
       "run_at": "document_start"

--- a/src/pages/Background/devconsole/messageHandler.js
+++ b/src/pages/Background/devconsole/messageHandler.js
@@ -9,10 +9,59 @@ import {
   setupTabListeners,
 } from './tabManager';
 
+const DEVCONSOLE_ALLOWED_PREFIXES = ['https://dev.primuslabs.xyz/'];
+const DEVCONSOLE_DEV_ALLOWED_PREFIXES = [
+  'http://localhost/',
+  'http://api-dev.padolabs.org:38082/',
+  'http://api-dev.padolabs.org:38089/',
+  'http://35.200.124.249/',
+];
+
+function getAllowedDevconsolePrefixes() {
+  if (process.env.NODE_ENV === 'development') {
+    return [
+      ...DEVCONSOLE_ALLOWED_PREFIXES,
+      ...DEVCONSOLE_DEV_ALLOWED_PREFIXES,
+    ];
+  }
+  return DEVCONSOLE_ALLOWED_PREFIXES;
+}
+
+function isAllowedDevconsoleUrl(url) {
+  if (typeof url !== 'string' || !url) return false;
+  return getAllowedDevconsolePrefixes().some((prefix) => url.startsWith(prefix));
+}
+
+function isMessageFromDevconsolePage(name, sender, state) {
+  if (!sender?.tab?.id || !sender?.tab?.url) return false;
+  if (!['init', 'closeDataSource'].includes(name)) return false;
+  if (state.devconsoleTabId && sender.tab.id !== state.devconsoleTabId) {
+    return false;
+  }
+  return isAllowedDevconsoleUrl(sender.tab.url);
+}
+
+function isMessageFromDataSourcePage(name, sender, state) {
+  if (name !== 'FAVICON_URL') return false;
+  return sender?.tab?.id === state.checkDataSourcePageTabId;
+}
+
 export async function devconsoleMsgListener(request, sender, sendResponse) {
   try {
     const { name, params } = request;
     const state = getDevconsoleState();
+
+    if (
+      !isMessageFromDevconsolePage(name, sender, state) &&
+      !isMessageFromDataSourcePage(name, sender, state)
+    ) {
+      console.warn('devconsoleMsgListener blocked unexpected sender', {
+        name,
+        tabId: sender?.tab?.id,
+        url: sender?.tab?.url,
+      });
+      return;
+    }
 
     if (name === 'init') {
       resetDevconsoleState();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,12 @@ var FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 // const CircularDependencyPlugin = require('circular-dependency-plugin');
 const ASSET_PATH = process.env.ASSET_PATH || '/';
+const DEVCONSOLE_DEV_MATCHES = [
+  'http://localhost/*',
+  'http://api-dev.padolabs.org:38082/*',
+  'http://api-dev.padolabs.org:38089/*',
+  'http://35.200.124.249/*',
+];
 
 var alias = {
   '@': path.resolve(__dirname, './src'),
@@ -219,16 +225,29 @@ var options = {
           force: true,
           transform: function (content, path) {
             // generates the manifest file using the package.json informations
+            const manifest = JSON.parse(content.toString());
             if (process.env.NODE_ENV === 'production') {
               return Buffer.from(
                 JSON.stringify({
                   description: process.env.npm_package_description,
                   version: process.env.npm_package_version,
-                  ...JSON.parse(content.toString()),
+                  ...manifest,
                 })
               );
             } else {
-              let jsonobj = JSON.parse(content.toString());
+              let jsonobj = manifest;
+              const devconsoleScript = jsonobj.content_scripts.find(
+                (script) =>
+                  Array.isArray(script.js) &&
+                  script.js.includes('devconsole.bundle.js')
+              );
+              if (devconsoleScript) {
+                const existingMatches = new Set(devconsoleScript.matches || []);
+                DEVCONSOLE_DEV_MATCHES.forEach((match) =>
+                  existingMatches.add(match)
+                );
+                devconsoleScript.matches = Array.from(existingMatches);
+              }
               //jsonobj.content_scripts[0].matches.push("http://api-dev.padolabs.org:9094/*");
               jsonobj.content_scripts[0].matches.push(
                 'http://api-dev.padolabs.org:9095/*'


### PR DESCRIPTION
## Summary
- restrict production devconsole injection to https://dev.primuslabs.xyz/*
- add development-only devconsole matches during webpack manifest generation for local and legacy dev hosts
- validate sender.tab.url in the devconsole background handler so only trusted devconsole pages and the current data-source tab can message the route

## Testing
- npm run build
